### PR TITLE
Fix Spotify login URL encoding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ addopts = [
     "--cov-report=html:htmlcov",
 ]
 asyncio_mode = "auto"
+markers = [
+    "asyncio: mark test as requiring the pytest-asyncio plugin",
+]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/rspotify_bot/services/auth.py
+++ b/rspotify_bot/services/auth.py
@@ -10,6 +10,7 @@ from typing import Callable, Any, Dict, Optional
 from datetime import datetime, timedelta, timezone
 from telegram import Update
 from telegram.ext import ContextTypes
+from urllib.parse import urlencode, quote
 
 from ..config import Config
 
@@ -147,8 +148,8 @@ class SpotifyAuthService:
             "scope": scope,
         }
 
-        # Build query string
-        query_params = "&".join([f"{k}={v}" for k, v in params.items()])
+        # Build query string with proper URL encoding
+        query_params = urlencode(params, quote_via=quote)
         auth_url = f"{self.SPOTIFY_AUTHORIZE_URL}?{query_params}"
 
         logger.debug(f"Generated authorization URL with state: {state}")


### PR DESCRIPTION
## Summary
- properly URL-encode the Spotify authorization link generated for /login to avoid malformed query strings
- update the authorization URL unit test to parse and validate encoded query parameters
- register the pytest asyncio marker in configuration so strict marker checking passes

## Testing
- PYTHONPATH=. pytest tests/unit/test_oauth.py::TestSpotifyAuthService::test_get_authorization_url -q

------
https://chatgpt.com/codex/tasks/task_b_68e0f08c0440832997027a4289e9c25c