### PR TITLE
Fix OAuth callback database insert crash

### DIFF
--- a/web_callback/app.py
+++ b/web_callback/app.py
@@ -301,7 +301,8 @@ async def spotify_callback(request: web.Request) -> web.Response:
         }
 
         try:
-            result = await db_service.database.oauth_codes.insert_one(code_doc)
+            insert_oauth_code = db_service.database.oauth_codes.insert_one
+            result = await asyncio.to_thread(insert_oauth_code, code_doc)
         except PyMongoError as e:
             logger.error('Failed to store auth code in database: %s', e, exc_info=True)
             return web.Response(


### PR DESCRIPTION
## Summary
- avoid awaiting the synchronous Mongo insert in the OAuth callback by offloading it to a thread

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e1156bd6e4832986c105cc03395cb2