### PR TITLE
Feature/story 1.5 custom name setup management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ addopts = [
 ]
 markers = [
     "asyncio: mark test as requiring the asyncio test harness",
+    "integration: mark test as integration test requiring external services",
 ]
 [tool.setuptools.packages.find]
 where = ["."]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,7 +5,7 @@
 pytest==7.4
 pytest-asyncio==0.21.1
 pytest-mock==3.12.0
-pytest-cov==4.1.0-r requirements.txt
+pytest-cov==4.1.0
 pytest==7.4
 pytest-asyncio==0.21.1
 pytest-mock==3.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv==1.0.0
 cryptography==41.0.7
 certbot==2.7.4
 acme==2.7.4
+better-profanity==0.7.0

--- a/tests/integration/test_spotify_profile_integration.py
+++ b/tests/integration/test_spotify_profile_integration.py
@@ -1,0 +1,188 @@
+"""
+Integration tests for Spotify profile fetching (Story 1.5).
+Tests real API calls to Spotify's /v1/me endpoint.
+
+NOTE: These tests require valid Spotify credentials in .env file.
+Set SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET, and have a test access token.
+"""
+
+import pytest
+import os
+from unittest.mock import patch
+from rspotify_bot.services.auth import SpotifyAuthService
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.getenv("SPOTIFY_CLIENT_ID") or not os.getenv("SPOTIFY_CLIENT_SECRET"),
+    reason="Spotify credentials not configured"
+)
+class TestSpotifyProfileIntegration:
+    """Integration tests for Spotify profile API."""
+
+    @pytest.mark.asyncio
+    async def test_get_user_profile_with_valid_token(self):
+        """
+        Test fetching user profile with a valid access token.
+        
+        This test uses a mocked token since we don't have a real one in CI.
+        In a real environment, you would use a test user's actual token.
+        """
+        auth_service = SpotifyAuthService()
+        
+        # Mock the actual HTTP call since we can't use a real token in tests
+        from unittest.mock import AsyncMock, MagicMock
+        
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "display_name": "Test User",
+            "email": "test@example.com",
+            "product": "premium",
+            "country": "US",
+            "id": "test_user_123"
+        }
+        
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = MockClient.return_value.__aenter__.return_value
+            mock_client.get = AsyncMock(return_value=mock_response)
+            
+            profile = await auth_service.get_user_profile("mock_access_token")
+        
+        # Verify response structure
+        assert profile is not None
+        assert "display_name" in profile
+        assert "email" in profile
+        assert "product" in profile
+        assert "country" in profile
+        assert "id" in profile
+        
+        # Verify data types
+        assert isinstance(profile["display_name"], (str, type(None)))
+        assert isinstance(profile["product"], str)
+
+    @pytest.mark.asyncio
+    async def test_get_user_profile_with_expired_token(self):
+        """Test that expired tokens are handled gracefully."""
+        auth_service = SpotifyAuthService()
+        
+        # Mock 401 response for expired token
+        from unittest.mock import AsyncMock, MagicMock
+        
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "The access token expired"
+        
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = MockClient.return_value.__aenter__.return_value
+            mock_client.get = AsyncMock(return_value=mock_response)
+            
+            with pytest.raises(Exception) as exc_info:
+                await auth_service.get_user_profile("expired_token")
+            
+            assert "expired or invalid" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_get_user_profile_free_account(self):
+        """Test profile fetching for free Spotify account."""
+        auth_service = SpotifyAuthService()
+        
+        from unittest.mock import AsyncMock, MagicMock
+        
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "display_name": "Free User",
+            "email": "free@example.com",
+            "product": "free",  # Free account
+            "country": "US",
+            "id": "free_user_123"
+        }
+        
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = MockClient.return_value.__aenter__.return_value
+            mock_client.get = AsyncMock(return_value=mock_response)
+            
+            profile = await auth_service.get_user_profile("mock_token")
+        
+        assert profile["product"] == "free"
+
+    @pytest.mark.asyncio
+    async def test_get_user_profile_premium_account(self):
+        """Test profile fetching for premium Spotify account."""
+        auth_service = SpotifyAuthService()
+        
+        from unittest.mock import AsyncMock, MagicMock
+        
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "display_name": "Premium User",
+            "email": "premium@example.com",
+            "product": "premium",  # Premium account
+            "country": "US",
+            "id": "premium_user_123"
+        }
+        
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = MockClient.return_value.__aenter__.return_value
+            mock_client.get = AsyncMock(return_value=mock_response)
+            
+            profile = await auth_service.get_user_profile("mock_token")
+        
+        assert profile["product"] == "premium"
+
+    @pytest.mark.asyncio
+    async def test_get_user_profile_network_error(self):
+        """Test handling of network errors."""
+        auth_service = SpotifyAuthService()
+        
+        from unittest.mock import AsyncMock
+        import httpx
+        
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = MockClient.return_value.__aenter__.return_value
+            mock_client.get = AsyncMock(side_effect=httpx.RequestError("Network error"))
+            
+            with pytest.raises(Exception) as exc_info:
+                await auth_service.get_user_profile("mock_token")
+            
+            assert "network error" in str(exc_info.value).lower()
+
+
+@pytest.mark.integration
+class TestDefaultNameFallbackIntegration:
+    """Integration tests for default name fallback logic."""
+
+    @pytest.mark.asyncio
+    async def test_default_name_fallback_hierarchy(self):
+        """
+        Test that default name follows correct fallback hierarchy:
+        1. Spotify display name
+        2. Telegram username
+        3. Telegram first name
+        4. "User"
+        """
+        # This would be tested as part of the full OAuth flow
+        # For now, we verify the logic exists in the bot
+        from rspotify_bot.bot import RSpotifyBot
+        
+        bot = RSpotifyBot("test_token")
+        
+        # Verify the method exists
+        assert hasattr(bot, "_get_default_name")
+        
+        # Test with mock data
+        from types import SimpleNamespace
+        
+        telegram_user = SimpleNamespace(
+            id=123456789,
+            username="testuser",
+            first_name="Test"
+        )
+        
+        # Without Spotify, should use Telegram username
+        default_name = await bot._get_default_name(telegram_user)
+        # Will be "testuser" or "Test" or "User" depending on what's available
+        assert default_name in ["testuser", "Test", "User"]
+        assert len(default_name) <= 12  # Respects 12 char limit

--- a/tests/unit/test_bot_oauth.py
+++ b/tests/unit/test_bot_oauth.py
@@ -54,6 +54,9 @@ async def test_handle_oauth_code_updates_tokens(monkeypatch: pytest.MonkeyPatch)
         message=message,
         effective_user=SimpleNamespace(id=123456789),
     )
+    
+    # Add context parameter
+    context = SimpleNamespace(user_data={})
 
     auth_service = SimpleNamespace(
         exchange_code_for_tokens=AsyncMock(
@@ -70,7 +73,8 @@ async def test_handle_oauth_code_updates_tokens(monkeypatch: pytest.MonkeyPatch)
     )
 
     repo_instance = SimpleNamespace(
-        update_spotify_tokens=AsyncMock(return_value=True)
+        update_spotify_tokens=AsyncMock(return_value=True),
+        get_user=AsyncMock(return_value={"custom_name": "TestUser"})  # Add get_user mock
     )
 
     def repo_factory(database):
@@ -82,7 +86,7 @@ async def test_handle_oauth_code_updates_tokens(monkeypatch: pytest.MonkeyPatch)
         repo_factory,
     )
 
-    await bot._handle_oauth_code(update, str(object_id), update.effective_user.id)
+    await bot._handle_oauth_code(update, context, str(object_id), update.effective_user.id)
 
     auth_service.exchange_code_for_tokens.assert_awaited_once_with(auth_code)
     repo_instance.update_spotify_tokens.assert_awaited_once_with(

--- a/tests/unit/test_user_profile_commands.py
+++ b/tests/unit/test_user_profile_commands.py
@@ -1,0 +1,350 @@
+"""
+Unit tests for user profile commands (Story 1.5).
+Tests /me and /rename commands.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timezone
+
+
+class TestMeCommand:
+    """Test suite for /me command."""
+
+    @pytest.mark.asyncio
+    async def test_me_command_with_spotify_connected(self):
+        """Test /me command when user has Spotify connected."""
+        from rspotify_bot.handlers.user_commands import handle_me
+        
+        # Mock update and context
+        update = MagicMock()
+        context = MagicMock()
+        
+        # Mock user
+        user = MagicMock()
+        user.id = 123456789
+        update.effective_user = user
+        
+        # Mock message
+        message = AsyncMock()
+        update.message = message
+        
+        # Mock database service
+        db_service = MagicMock()
+        db_service.database = MagicMock()
+        context.bot_data = {"db_service": db_service}
+        
+        # Mock user data with Spotify connected
+        user_data = {
+            "telegram_id": 123456789,
+            "custom_name": "TestUser",
+            "spotify": {
+                "access_token": "test_token",
+                "refresh_token": "test_refresh",
+            },
+            "created_at": datetime(2025, 1, 1, tzinfo=timezone.utc),
+        }
+        
+        # Mock Spotify profile
+        spotify_profile = {
+            "display_name": "Test User",
+            "product": "premium",
+            "email": "test@example.com",
+        }
+        
+        with patch("rspotify_bot.handlers.user_commands.UserRepository") as MockRepo:
+            mock_repo = MockRepo.return_value
+            mock_repo.get_user = AsyncMock(return_value=user_data)
+            
+            with patch("rspotify_bot.handlers.user_commands.SpotifyAuthService") as MockAuth:
+                mock_auth = MockAuth.return_value
+                mock_auth.get_user_profile = AsyncMock(return_value=spotify_profile)
+                
+                await handle_me(update, context)
+        
+        # Verify reply was sent
+        message.reply_html.assert_called_once()
+        call_args = message.reply_html.call_args[0][0]
+        
+        assert "TestUser" in call_args
+        assert "Connected" in call_args
+        assert "Premium" in call_args
+
+    @pytest.mark.asyncio
+    async def test_me_command_without_spotify(self):
+        """Test /me command when user doesn't have Spotify connected."""
+        from rspotify_bot.handlers.user_commands import handle_me
+        
+        update = MagicMock()
+        context = MagicMock()
+        
+        user = MagicMock()
+        user.id = 123456789
+        update.effective_user = user
+        
+        message = AsyncMock()
+        update.message = message
+        
+        db_service = MagicMock()
+        db_service.database = MagicMock()
+        context.bot_data = {"db_service": db_service}
+        
+        # User data without Spotify
+        user_data = {
+            "telegram_id": 123456789,
+            "custom_name": "TestUser",
+            "spotify": None,
+            "created_at": datetime(2025, 1, 1, tzinfo=timezone.utc),
+        }
+        
+        with patch("rspotify_bot.handlers.user_commands.UserRepository") as MockRepo:
+            mock_repo = MockRepo.return_value
+            mock_repo.get_user = AsyncMock(return_value=user_data)
+            
+            await handle_me(update, context)
+        
+        message.reply_html.assert_called_once()
+        call_args = message.reply_html.call_args[0][0]
+        
+        assert "TestUser" in call_args
+        assert "Disconnected" in call_args
+
+    @pytest.mark.asyncio
+    async def test_me_command_user_not_found(self):
+        """Test /me command when user profile doesn't exist."""
+        from rspotify_bot.handlers.user_commands import handle_me
+        
+        update = MagicMock()
+        context = MagicMock()
+        
+        user = MagicMock()
+        user.id = 123456789
+        update.effective_user = user
+        
+        message = AsyncMock()
+        update.message = message
+        
+        db_service = MagicMock()
+        db_service.database = MagicMock()
+        context.bot_data = {"db_service": db_service}
+        
+        with patch("rspotify_bot.handlers.user_commands.UserRepository") as MockRepo:
+            mock_repo = MockRepo.return_value
+            mock_repo.get_user = AsyncMock(return_value=None)
+            
+            await handle_me(update, context)
+        
+        message.reply_html.assert_called_once()
+        call_args = message.reply_html.call_args[0][0]
+        
+        assert "Not Found" in call_args
+
+
+class TestRenameCommand:
+    """Test suite for /rename command."""
+
+    @pytest.mark.asyncio
+    async def test_rename_command_initiates_flow(self):
+        """Test /rename command initiates rename flow."""
+        from rspotify_bot.handlers.user_commands import handle_rename
+        
+        update = MagicMock()
+        context = MagicMock()
+        context.user_data = {}
+        
+        user = MagicMock()
+        user.id = 123456789
+        update.effective_user = user
+        
+        message = AsyncMock()
+        update.message = message
+        
+        await handle_rename(update, context)
+        
+        # Verify prompt was sent
+        message.reply_html.assert_called_once()
+        call_args = message.reply_html.call_args[0][0]
+        
+        assert "new custom display name" in call_args.lower() or "display name" in call_args.lower()
+        
+        # Verify state was set
+        assert context.user_data.get("awaiting_rename") is True
+
+    @pytest.mark.asyncio
+    async def test_rename_command_rate_limit(self):
+        """Test /rename command respects rate limiting."""
+        from rspotify_bot.handlers.user_commands import handle_rename
+        from datetime import timedelta
+        
+        update = MagicMock()
+        context = MagicMock()
+        
+        # Set up rename history with 3 recent renames
+        current_time = datetime.now(timezone.utc)
+        context.user_data = {
+            "rename_history": [
+                current_time - timedelta(minutes=5),
+                current_time - timedelta(minutes=10),
+                current_time - timedelta(minutes=15),
+            ]
+        }
+        
+        user = MagicMock()
+        user.id = 123456789
+        update.effective_user = user
+        
+        message = AsyncMock()
+        update.message = message
+        
+        await handle_rename(update, context)
+        
+        # Verify rate limit message was sent
+        message.reply_html.assert_called_once()
+        call_args = message.reply_html.call_args[0][0]
+        
+        assert "Rate Limit" in call_args or "too many times" in call_args.lower()
+
+    @pytest.mark.asyncio
+    async def test_rename_input_valid_name(self):
+        """Test rename input handler with valid name."""
+        from rspotify_bot.handlers.user_commands import handle_rename_input
+        
+        update = MagicMock()
+        context = MagicMock()
+        context.user_data = {"awaiting_rename": True, "rename_history": []}
+        
+        user = MagicMock()
+        user.id = 123456789
+        update.effective_user = user
+        
+        message = AsyncMock()
+        message.text = "NewName"
+        update.message = message
+        
+        db_service = MagicMock()
+        db_service.database = MagicMock()
+        context.bot_data = {"db_service": db_service}
+        
+        with patch("rspotify_bot.handlers.user_commands.UserRepository") as MockRepo:
+            mock_repo = MockRepo.return_value
+            mock_repo.update_user = AsyncMock(return_value=True)
+            
+            await handle_rename_input(update, context)
+        
+        # Verify success message
+        message.reply_html.assert_called_once()
+        call_args = message.reply_html.call_args[0][0]
+        
+        assert "NewName" in call_args
+        assert "Updated" in call_args or "changed" in call_args.lower()
+        
+        # Verify state was cleared
+        assert context.user_data.get("awaiting_rename") is False
+
+    @pytest.mark.asyncio
+    async def test_rename_input_invalid_name(self):
+        """Test rename input handler with invalid name."""
+        from rspotify_bot.handlers.user_commands import handle_rename_input
+        
+        update = MagicMock()
+        context = MagicMock()
+        context.user_data = {"awaiting_rename": True}
+        
+        user = MagicMock()
+        user.id = 123456789
+        update.effective_user = user
+        
+        message = AsyncMock()
+        message.text = "ThisNameIsTooLong"  # More than 12 characters
+        update.message = message
+        
+        await handle_rename_input(update, context)
+        
+        # Verify error message
+        message.reply_html.assert_called_once()
+        call_args = message.reply_html.call_args[0][0]
+        
+        assert "Invalid" in call_args or "too long" in call_args.lower()
+        
+        # Verify state is still active for retry
+        assert context.user_data.get("awaiting_rename") is True
+
+    @pytest.mark.asyncio
+    async def test_rename_input_cancel(self):
+        """Test rename input handler with cancel command."""
+        from rspotify_bot.handlers.user_commands import handle_rename_input
+        
+        update = MagicMock()
+        context = MagicMock()
+        context.user_data = {"awaiting_rename": True}
+        
+        user = MagicMock()
+        user.id = 123456789
+        update.effective_user = user
+        
+        message = AsyncMock()
+        message.text = "/cancel"
+        update.message = message
+        
+        await handle_rename_input(update, context)
+        
+        # Verify cancelled message
+        message.reply_html.assert_called_once()
+        call_args = message.reply_html.call_args[0][0]
+        
+        assert "Cancel" in call_args
+        
+        # Verify state was cleared
+        assert context.user_data.get("awaiting_rename") is False
+
+
+class TestSpotifyProfileFetching:
+    """Test suite for Spotify profile fetching."""
+
+    @pytest.mark.asyncio
+    async def test_get_user_profile_success(self):
+        """Test successful Spotify profile fetch."""
+        from rspotify_bot.services.auth import SpotifyAuthService
+        import httpx
+        
+        auth_service = SpotifyAuthService()
+        
+        # Mock response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "display_name": "Test User",
+            "email": "test@example.com",
+            "product": "premium",
+            "country": "US",
+            "id": "spotify_user_123",
+        }
+        
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = MockClient.return_value.__aenter__.return_value
+            mock_client.get = AsyncMock(return_value=mock_response)
+            
+            profile = await auth_service.get_user_profile("test_token")
+        
+        assert profile["display_name"] == "Test User"
+        assert profile["product"] == "premium"
+        assert profile["email"] == "test@example.com"
+
+    @pytest.mark.asyncio
+    async def test_get_user_profile_expired_token(self):
+        """Test Spotify profile fetch with expired token."""
+        from rspotify_bot.services.auth import SpotifyAuthService
+        
+        auth_service = SpotifyAuthService()
+        
+        # Mock 401 response
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+        
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = MockClient.return_value.__aenter__.return_value
+            mock_client.get = AsyncMock(return_value=mock_response)
+            
+            with pytest.raises(Exception, match="expired or invalid"):
+                await auth_service.get_user_profile("expired_token")


### PR DESCRIPTION
This pull request introduces major enhancements to the user onboarding and profile management experience in the Spotify Telegram bot. The main changes add a personalized "custom display name" feature, including onboarding prompts, validation, and rate-limited renaming. Additionally, a new `/me` command lets users view their profile, and a `/rename` command allows changing their display name. Supporting logic for fetching Spotify profile data and validating names has also been added.

**User onboarding and profile management:**

* Added onboarding flow that prompts new users to set a custom display name after connecting Spotify, with the option to skip or use a default name (derived from Spotify, Telegram, or fallback) (`rspotify_bot/bot.py`) [[1]](diffhunk://#diff-32cea361cf795fdaee256c948e25efd7d85aea0d5767e8ac87af86c773c28288R383-R405) [[2]](diffhunk://#diff-32cea361cf795fdaee256c948e25efd7d85aea0d5767e8ac87af86c773c28288R428-R560).
* Implemented the `/me` command to display user profile info, including custom name, Spotify connection status, account type, and membership date (`rspotify_bot/handlers/user_commands.py`) [[1]](diffhunk://#diff-2def5f88f7709ef3af42c05f0ae3391698a1aa993ff5ef97c26c7d4ea0b32460R401-R640) [[2]](diffhunk://#diff-2def5f88f7709ef3af42c05f0ae3391698a1aa993ff5ef97c26c7d4ea0b32460R654-R655).
* Added the `/rename` command with rate limiting (3 renames/hour), input validation, and conversation state management for changing the custom display name (`rspotify_bot/handlers/user_commands.py`, `rspotify_bot/bot.py`) [[1]](diffhunk://#diff-2def5f88f7709ef3af42c05f0ae3391698a1aa993ff5ef97c26c7d4ea0b32460R401-R640) [[2]](diffhunk://#diff-2def5f88f7709ef3af42c05f0ae3391698a1aa993ff5ef97c26c7d4ea0b32460R654-R655) [[3]](diffhunk://#diff-32cea361cf795fdaee256c948e25efd7d85aea0d5767e8ac87af86c773c28288R428-R560).

**Spotify integration and validation:**

* Added `get_user_profile` method to `SpotifyAuthService` for fetching Spotify user profile data, used for default display name and account type (`rspotify_bot/services/auth.py`).
* Introduced profanity filtering and improved validation for custom display names (`rspotify_bot/services/validation.py`).

**Other improvements:**

* Added a new pytest marker for integration tests (`pyproject.toml`).
* Fixed a typo in test requirements (`requirements-test.txt`).

These changes collectively provide a more personalized and robust user experience, making onboarding smoother and giving users greater control over their profile and display identity.